### PR TITLE
Old School Mode

### DIFF
--- a/lua/tacrp/shared/sh_0_convar.lua
+++ b/lua/tacrp/shared/sh_0_convar.lua
@@ -914,7 +914,7 @@ local function menu_balance_ti(panel)
     panel:Help("Arcade: Balanced for Sandbox move speed. Low TTK. Snipers/DMRs have damage rampup.")
     panel:Help("TTT: High TTK, reloads slow you down and take longer. Some weapons have lower fire rate.")
     panel:Help("PvE: For HL2 campaign or co-op maps. Damage comparable to HL2 weapons, reduced spread.")
-    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire and moving spread, more intense bloom.")
+    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire, no moving spread, more intense bloom.")
     panel:Help("(Tactical and PvE separate weapons into 4 tiers, ranging from Consumer, Security, Operator, and Elite, with each higher tier having slightly better damage output.)")
 
     header(panel, "\nAmmunition")

--- a/lua/tacrp/shared/sh_0_convar.lua
+++ b/lua/tacrp/shared/sh_0_convar.lua
@@ -914,7 +914,7 @@ local function menu_balance_ti(panel)
     panel:Help("Arcade: Balanced for Sandbox move speed. Low TTK. Snipers/DMRs have damage rampup.")
     panel:Help("TTT: High TTK, reloads slow you down and take longer. Some weapons have lower fire rate.")
     panel:Help("PvE: For HL2 campaign or co-op maps. Damage comparable to HL2 weapons, reduced spread.")
-    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire, no moving spread, more intense bloom. (Pairs well with bloom modifying recoil.)")
+    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire, no moving spread, more intense bloom.")
     panel:Help("(Tactical and PvE separate weapons into 4 tiers, ranging from Consumer, Security, Operator, and Elite, with each higher tier having slightly better damage output.)")
 
     header(panel, "\nAmmunition")

--- a/lua/tacrp/shared/sh_0_convar.lua
+++ b/lua/tacrp/shared/sh_0_convar.lua
@@ -914,7 +914,7 @@ local function menu_balance_ti(panel)
     panel:Help("Arcade: Balanced for Sandbox move speed. Low TTK. Snipers/DMRs have damage rampup.")
     panel:Help("TTT: High TTK, reloads slow you down and take longer. Some weapons have lower fire rate.")
     panel:Help("PvE: For HL2 campaign or co-op maps. Damage comparable to HL2 weapons, reduced spread.")
-    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire, no moving spread, more intense bloom.")
+    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire, no moving spread, more intense bloom. (Pairs well with bloom modifying recoil.)")
     panel:Help("(Tactical and PvE separate weapons into 4 tiers, ranging from Consumer, Security, Operator, and Elite, with each higher tier having slightly better damage output.)")
 
     header(panel, "\nAmmunition")

--- a/lua/tacrp/shared/sh_0_convar.lua
+++ b/lua/tacrp/shared/sh_0_convar.lua
@@ -301,7 +301,7 @@ local conVars = {
         name = "balance",
         default = "-1",
         min = -1,
-        max = 3,
+        max = 4,
         replicated = true,
         notify = true,
     },
@@ -906,6 +906,7 @@ local function menu_balance_ti(panel)
     cb_balance:AddChoice("1 - Arcade", "1")
     cb_balance:AddChoice("2 - TTT", "2")
     cb_balance:AddChoice("3 - PvE", "3")
+    cb_balance:AddChoice("4 - Old School", "4")
     cb_balance:DockMargin(8, 0, 0, 0)
     lb_balance:SizeToContents()
 
@@ -913,6 +914,7 @@ local function menu_balance_ti(panel)
     panel:Help("Arcade: Balanced for Sandbox move speed. Low TTK. Snipers/DMRs have damage rampup.")
     panel:Help("TTT: High TTK, reloads slow you down and take longer. Some weapons have lower fire rate.")
     panel:Help("PvE: For HL2 campaign or co-op maps. Damage comparable to HL2 weapons, reduced spread.")
+    panel:Help("Old School: Novelty mode that emphasizes movement and penalizes long sprays. No ironsights, tight hipfire and moving spread, more intense bloom.")
     panel:Help("(Tactical and PvE separate weapons into 4 tiers, ranging from Consumer, Security, Operator, and Elite, with each higher tier having slightly better damage output.)")
 
     header(panel, "\nAmmunition")

--- a/lua/tacrp/shared/sh_0_convar.lua
+++ b/lua/tacrp/shared/sh_0_convar.lua
@@ -914,7 +914,7 @@ local function menu_balance_ti(panel)
     panel:Help("Arcade: Balanced for Sandbox move speed. Low TTK. Snipers/DMRs have damage rampup.")
     panel:Help("TTT: High TTK, reloads slow you down and take longer. Some weapons have lower fire rate.")
     panel:Help("PvE: For HL2 campaign or co-op maps. Damage comparable to HL2 weapons, reduced spread.")
-    panel:Help("Old School: Novelty mode that emphasizes movement and penalizes long sprays. No ironsights, tight hipfire and moving spread, more intense bloom.")
+    panel:Help("Old School: Novelty mode that alters gameplay to feel a bit more retro, emphasizing movement and spray control. No ironsights, tight hipfire and moving spread, more intense bloom.")
     panel:Help("(Tactical and PvE separate weapons into 4 tiers, ranging from Consumer, Security, Operator, and Elite, with each higher tier having slightly better damage output.)")
 
     header(panel, "\nAmmunition")

--- a/lua/tacrp/shared/sh_common.lua
+++ b/lua/tacrp/shared/sh_common.lua
@@ -183,7 +183,7 @@ TacRP.BalanceDefaults = {
 
         MeleeSpeedMult = 1,
         ShootingSpeedMult = 1,
-        SightedSpeedMult = 0.9,
+        SightedSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
 }

--- a/lua/tacrp/shared/sh_common.lua
+++ b/lua/tacrp/shared/sh_common.lua
@@ -140,6 +140,7 @@ TacRP.BALANCE_RP = 0
 TacRP.BALANCE_SBOX = 1
 TacRP.BALANCE_TTT = 2
 TacRP.BALANCE_PVE = 3
+TacRP.BALANCE_OLDSCHOOL = 4
 
 function TacRP.GetBalanceMode()
     local i = TacRP.ConVars["balance"]:GetInt()
@@ -173,7 +174,18 @@ TacRP.BalanceDefaults = {
             [HITGROUP_RIGHTLEG] = 0.75,
             [HITGROUP_GEAR] = 0.75
         }
-    }
+    },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 30,
+
+        MoveSpreadPenalty = 0.005,
+        HipFireSpreadPenalty = 0.007,
+
+        MeleeSpeedMult = 1,
+        ShootingSpeedMult = 1,
+        SightedSpeedMult = 0.9,
+        ReloadSpeedMult = 1,
+    },
 }
 
 function TacRP.UseTiers()

--- a/lua/tacrp/shared/sh_common.lua
+++ b/lua/tacrp/shared/sh_common.lua
@@ -177,6 +177,7 @@ TacRP.BalanceDefaults = {
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
         RecoilDissipationRate = 30,
+		RecoilVisualKick = 0.5,
 
         MoveSpreadPenalty = 0,
         HipFireSpreadPenalty = 0.007,

--- a/lua/tacrp/shared/sh_common.lua
+++ b/lua/tacrp/shared/sh_common.lua
@@ -176,6 +176,7 @@ TacRP.BalanceDefaults = {
         }
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 30,
 		RecoilVisualKick = 0.5,
 
         MoveSpreadPenalty = 0,

--- a/lua/tacrp/shared/sh_common.lua
+++ b/lua/tacrp/shared/sh_common.lua
@@ -178,7 +178,7 @@ TacRP.BalanceDefaults = {
     [TacRP.BALANCE_OLDSCHOOL] = {
         RecoilDissipationRate = 30,
 
-        MoveSpreadPenalty = 0.005,
+        MoveSpreadPenalty = 0,
         HipFireSpreadPenalty = 0.007,
 
         MeleeSpeedMult = 1,

--- a/lua/tacrp/shared/sh_common.lua
+++ b/lua/tacrp/shared/sh_common.lua
@@ -176,7 +176,6 @@ TacRP.BalanceDefaults = {
         }
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 30,
 		RecoilVisualKick = 0.5,
 
         MoveSpreadPenalty = 0,

--- a/lua/weapons/tacrp_ak47.lua
+++ b/lua/weapons/tacrp_ak47.lua
@@ -71,10 +71,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 20,
-        RecoilSpreadPenalty = 0.003,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ak47.lua
+++ b/lua/weapons/tacrp_ak47.lua
@@ -71,6 +71,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.003,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_amd65.lua
+++ b/lua/weapons/tacrp_amd65.lua
@@ -79,6 +79,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.0035,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_amd65.lua
+++ b/lua/weapons/tacrp_amd65.lua
@@ -79,10 +79,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 20,
-        RecoilSpreadPenalty = 0.0035,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_as50.lua
+++ b/lua/weapons/tacrp_as50.lua
@@ -79,7 +79,7 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 1,
+        RecoilDissipationRate = 2,
         RecoilMaximum = 20,
         RecoilSpreadPenalty = 0.035,
 

--- a/lua/weapons/tacrp_as50.lua
+++ b/lua/weapons/tacrp_as50.lua
@@ -78,13 +78,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 2,
-        RecoilMaximum = 20,
-        RecoilSpreadPenalty = 0.035,
-
-        HipFireSpreadPenalty = 0.025,
-    }
 }
 
 // "ballistics"

--- a/lua/weapons/tacrp_as50.lua
+++ b/lua/weapons/tacrp_as50.lua
@@ -18,7 +18,6 @@ SWEP.WorldModel = "models/weapons/tacint/w_as50.mdl"
 SWEP.Slot = 2
 SWEP.SlotAlt = 3
 
-
 SWEP.BalanceStats = {
     [TacRP.BALANCE_SBOX] = {
         Description = "Semi-automatic anti-materiel rifle with integral bipod.\nCan kill in up to 2 shots regardless of distance.\nEquipped with a 12x scope by default.",
@@ -79,6 +78,13 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 1,
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.035,
+
+        HipFireSpreadPenalty = 0.025,
+    }
 }
 
 // "ballistics"

--- a/lua/weapons/tacrp_as50.lua
+++ b/lua/weapons/tacrp_as50.lua
@@ -78,6 +78,13 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 2,
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.035,
+
+        HipFireSpreadPenalty = 0.025,
+    }
 }
 
 // "ballistics"

--- a/lua/weapons/tacrp_aug.lua
+++ b/lua/weapons/tacrp_aug.lua
@@ -68,6 +68,12 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 9,
+        RecoilMaximum = 15,
+        RecoilSpreadPenalty = 0.005,
+        HipFireSpreadPenalty = 0.007,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_aug.lua
+++ b/lua/weapons/tacrp_aug.lua
@@ -68,12 +68,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 15,
-        RecoilMaximum = 15,
-        RecoilSpreadPenalty = 0.005,
-        HipFireSpreadPenalty = 0.007,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_aug.lua
+++ b/lua/weapons/tacrp_aug.lua
@@ -68,6 +68,12 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 15,
+        RecoilMaximum = 15,
+        RecoilSpreadPenalty = 0.005,
+        HipFireSpreadPenalty = 0.007,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_aug.lua
+++ b/lua/weapons/tacrp_aug.lua
@@ -69,7 +69,7 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 9,
+        RecoilDissipationRate = 15,
         RecoilMaximum = 15,
         RecoilSpreadPenalty = 0.005,
         HipFireSpreadPenalty = 0.007,

--- a/lua/weapons/tacrp_base/sh_scope.lua
+++ b/lua/weapons/tacrp_base/sh_scope.lua
@@ -51,6 +51,10 @@ function SWEP:ScopeToggle(setlevel)
         end
     end
 
+    if TacRP.GetBalanceMode() == TacRP.BALANCE_OLDSCHOOL and (!self:GetValue("ScopeOverlay") and !self:GetValue("Holosight")) and level > 0 then
+        level = 0
+    end
+
     if level == self:GetScopeLevel() then return end
 
     if IsFirstTimePredicted() then

--- a/lua/weapons/tacrp_bekas.lua
+++ b/lua/weapons/tacrp_bekas.lua
@@ -76,6 +76,12 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 5,
+        RecoilMaximum = 12,
+        RecoilSpreadPenalty = 0.01,
+        HipFireSpreadPenalty = 0.02,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_bekas.lua
+++ b/lua/weapons/tacrp_bekas.lua
@@ -76,12 +76,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 5,
-        RecoilMaximum = 12,
-        RecoilSpreadPenalty = 0.01,
-        HipFireSpreadPenalty = 0.02,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_civ_mp5.lua
+++ b/lua/weapons/tacrp_civ_mp5.lua
@@ -88,6 +88,12 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 20,
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.005,
+        HipFireSpreadPenalty = 0.007,
+    }
 }
 
 SWEP.Range_Min = 1750

--- a/lua/weapons/tacrp_civ_mp5.lua
+++ b/lua/weapons/tacrp_civ_mp5.lua
@@ -88,12 +88,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 20,
-        RecoilMaximum = 20,
-        RecoilSpreadPenalty = 0.005,
-        HipFireSpreadPenalty = 0.007,
-    }
 }
 
 SWEP.Range_Min = 1750

--- a/lua/weapons/tacrp_civ_p90.lua
+++ b/lua/weapons/tacrp_civ_p90.lua
@@ -78,6 +78,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.003,
+    }
 }
 
 SWEP.TTTReplace = {}

--- a/lua/weapons/tacrp_civ_p90.lua
+++ b/lua/weapons/tacrp_civ_p90.lua
@@ -78,10 +78,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 20,
-        RecoilSpreadPenalty = 0.003,
-    }
 }
 
 SWEP.TTTReplace = {}

--- a/lua/weapons/tacrp_dsa58.lua
+++ b/lua/weapons/tacrp_dsa58.lua
@@ -79,6 +79,11 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 30,
+        RecoilSpreadPenalty = 0.006,
+        HipFireSpreadPenalty = 0.009,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.BattleRifle

--- a/lua/weapons/tacrp_dsa58.lua
+++ b/lua/weapons/tacrp_dsa58.lua
@@ -79,11 +79,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 30,
-        RecoilSpreadPenalty = 0.006,
-        HipFireSpreadPenalty = 0.009,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.BattleRifle

--- a/lua/weapons/tacrp_ex_ak47.lua
+++ b/lua/weapons/tacrp_ex_ak47.lua
@@ -69,6 +69,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.005,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ex_ak47.lua
+++ b/lua/weapons/tacrp_ex_ak47.lua
@@ -69,6 +69,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.006,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ex_ak47.lua
+++ b/lua/weapons/tacrp_ex_ak47.lua
@@ -70,7 +70,7 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.006,
+        RecoilSpreadPenalty = 0.005,
     }
 }
 

--- a/lua/weapons/tacrp_ex_ak47.lua
+++ b/lua/weapons/tacrp_ex_ak47.lua
@@ -69,9 +69,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.005,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ex_glock.lua
+++ b/lua/weapons/tacrp_ex_glock.lua
@@ -72,6 +72,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.03,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Pistol

--- a/lua/weapons/tacrp_ex_glock.lua
+++ b/lua/weapons/tacrp_ex_glock.lua
@@ -71,6 +71,9 @@ SWEP.BalanceStats = {
         SightedSpeedMult = 1,
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
+    },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.03,
     }
 }
 

--- a/lua/weapons/tacrp_ex_glock.lua
+++ b/lua/weapons/tacrp_ex_glock.lua
@@ -72,9 +72,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.03,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Pistol

--- a/lua/weapons/tacrp_ex_hecate.lua
+++ b/lua/weapons/tacrp_ex_hecate.lua
@@ -71,6 +71,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 2,
+        HipFireSpreadPenalty = 0.025,
+    }
 }
 
 // "ballistics"

--- a/lua/weapons/tacrp_ex_hecate.lua
+++ b/lua/weapons/tacrp_ex_hecate.lua
@@ -71,10 +71,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 2,
-        HipFireSpreadPenalty = 0.025,
-    }
 }
 
 // "ballistics"

--- a/lua/weapons/tacrp_ex_hecate.lua
+++ b/lua/weapons/tacrp_ex_hecate.lua
@@ -73,7 +73,7 @@ SWEP.BalanceStats = {
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
         RecoilDissipationRate = 2,
-        HipFireSpreadPenalty = 0.09,
+        HipFireSpreadPenalty = 0.025,
     }
 }
 

--- a/lua/weapons/tacrp_ex_hecate.lua
+++ b/lua/weapons/tacrp_ex_hecate.lua
@@ -71,6 +71,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 2,
+        HipFireSpreadPenalty = 0.09,
+    }
 }
 
 // "ballistics"

--- a/lua/weapons/tacrp_ex_m1911.lua
+++ b/lua/weapons/tacrp_ex_m1911.lua
@@ -89,11 +89,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilPerShot = 2,
-        RecoilDissipationRate = 15,
-        RecoilSpreadPenalty = 0.006,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Pistol

--- a/lua/weapons/tacrp_ex_m1911.lua
+++ b/lua/weapons/tacrp_ex_m1911.lua
@@ -88,6 +88,11 @@ SWEP.BalanceStats = {
         SightedSpeedMult = 1,
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
+    },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilPerShot = 2,
+        RecoilDissipationRate = 15,
+        RecoilSpreadPenalty = 0.006,
     }
 }
 

--- a/lua/weapons/tacrp_ex_m1911.lua
+++ b/lua/weapons/tacrp_ex_m1911.lua
@@ -89,6 +89,11 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilPerShot = 2,
+        RecoilDissipationRate = 15,
+        RecoilSpreadPenalty = 0.006,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Pistol

--- a/lua/weapons/tacrp_ex_m4a1.lua
+++ b/lua/weapons/tacrp_ex_m4a1.lua
@@ -68,6 +68,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 30,
+        RecoilPerShot = 2,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ex_m4a1.lua
+++ b/lua/weapons/tacrp_ex_m4a1.lua
@@ -68,10 +68,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 30,
-        RecoilPerShot = 2,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ex_mac10.lua
+++ b/lua/weapons/tacrp_ex_mac10.lua
@@ -77,6 +77,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.004
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_ex_mac10.lua
+++ b/lua/weapons/tacrp_ex_mac10.lua
@@ -77,9 +77,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.004
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_ex_mp9.lua
+++ b/lua/weapons/tacrp_ex_mp9.lua
@@ -60,6 +60,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.0035
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_ex_mp9.lua
+++ b/lua/weapons/tacrp_ex_mp9.lua
@@ -60,9 +60,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.0035
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_ex_ump45.lua
+++ b/lua/weapons/tacrp_ex_ump45.lua
@@ -68,6 +68,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 25
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG
@@ -161,7 +164,7 @@ SWEP.SprintPos = Vector(8, -1, -2)
 SWEP.SightAng = Angle(-0, 0, 0)
 SWEP.SightPos = Vector(-4.5, -7.5, -3.26)
 
-SWEP.CorrectivePos = Vector(0, 0, 0)
+SWEP.CorrectivePos = Vector(0.04, 0, 0.1)
 SWEP.CorrectiveAng = Angle(0, 0, 0)
 
 SWEP.HolsterVisible = true

--- a/lua/weapons/tacrp_ex_ump45.lua
+++ b/lua/weapons/tacrp_ex_ump45.lua
@@ -68,6 +68,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 25
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_ex_ump45.lua
+++ b/lua/weapons/tacrp_ex_ump45.lua
@@ -68,9 +68,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 25
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_fp6.lua
+++ b/lua/weapons/tacrp_fp6.lua
@@ -73,10 +73,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 1.5,
-        RecoilSpreadPenalty = 0.03
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_fp6.lua
+++ b/lua/weapons/tacrp_fp6.lua
@@ -73,6 +73,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 1.5,
+        RecoilSpreadPenalty = 0.03
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_g36k.lua
+++ b/lua/weapons/tacrp_g36k.lua
@@ -63,10 +63,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.003,
-        HipFireSpreadPenalty = 0.009
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_g36k.lua
+++ b/lua/weapons/tacrp_g36k.lua
@@ -63,6 +63,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.003,
+        HipFireSpreadPenalty = 0.009
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_k1a.lua
+++ b/lua/weapons/tacrp_k1a.lua
@@ -68,6 +68,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.009,
+        RecoilSpreadPenalty = 0.004
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_k1a.lua
+++ b/lua/weapons/tacrp_k1a.lua
@@ -68,10 +68,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.009,
-        RecoilSpreadPenalty = 0.003
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_k1a.lua
+++ b/lua/weapons/tacrp_k1a.lua
@@ -70,7 +70,7 @@ SWEP.BalanceStats = {
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
         HipFireSpreadPenalty = 0.009,
-        RecoilSpreadPenalty = 0.004
+        RecoilSpreadPenalty = 0.003
     }
 }
 

--- a/lua/weapons/tacrp_k1a.lua
+++ b/lua/weapons/tacrp_k1a.lua
@@ -68,6 +68,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.009,
+        RecoilSpreadPenalty = 0.003
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_ks23.lua
+++ b/lua/weapons/tacrp_ks23.lua
@@ -77,12 +77,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.04,
-        RecoilDissipationRate = 1.25,
-        RecoilMaximum = 5,
-        ReloadTimeMult = 1.3
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_ks23.lua
+++ b/lua/weapons/tacrp_ks23.lua
@@ -77,6 +77,12 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.04,
+        RecoilDissipationRate = 1.25,
+        RecoilMaximum = 5,
+        ReloadTimeMult = 1.3
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_m1.lua
+++ b/lua/weapons/tacrp_m1.lua
@@ -78,9 +78,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-	[TacRP.BALANCE_OLDSCHOOL] = {
-		RecoilSpreadPenalty = 0.007
-	},
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_m1.lua
+++ b/lua/weapons/tacrp_m1.lua
@@ -78,6 +78,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+	[TacRP.BALANCE_OLDSCHOOL] = {
+		RecoilSpreadPenalty = 0.007
+	},
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_m14.lua
+++ b/lua/weapons/tacrp_m14.lua
@@ -80,11 +80,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.015,
-		RecoilSpreadPenalty = 0.01,
-		RecoilMaximum = 10
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MarksmanRifle

--- a/lua/weapons/tacrp_m14.lua
+++ b/lua/weapons/tacrp_m14.lua
@@ -80,6 +80,11 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.015,
+		RecoilSpreadPenalty = 0.01,
+		RecoilMaximum = 10
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MarksmanRifle

--- a/lua/weapons/tacrp_m14.lua
+++ b/lua/weapons/tacrp_m14.lua
@@ -80,6 +80,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.025
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MarksmanRifle

--- a/lua/weapons/tacrp_m14.lua
+++ b/lua/weapons/tacrp_m14.lua
@@ -81,7 +81,7 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.025
+        HipFireSpreadPenalty = 0.015
     }
 }
 

--- a/lua/weapons/tacrp_m14.lua
+++ b/lua/weapons/tacrp_m14.lua
@@ -81,7 +81,9 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.015
+        HipFireSpreadPenalty = 0.015,
+		RecoilSpreadPenalty = 0.01,
+		RecoilMaximum = 10
     }
 }
 

--- a/lua/weapons/tacrp_m4.lua
+++ b/lua/weapons/tacrp_m4.lua
@@ -70,6 +70,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 35,
+        RecoilSpreadPenalty = 0.05
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_m4.lua
+++ b/lua/weapons/tacrp_m4.lua
@@ -71,8 +71,8 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 35,
-        RecoilSpreadPenalty = 0.05
+        RecoilMaximum = 25,
+        RecoilPerShot = 2,
     }
 }
 

--- a/lua/weapons/tacrp_m4.lua
+++ b/lua/weapons/tacrp_m4.lua
@@ -70,10 +70,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 25,
-        RecoilPerShot = 2,
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_m4.lua
+++ b/lua/weapons/tacrp_m4.lua
@@ -70,6 +70,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 25,
+        RecoilPerShot = 2,
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_m4star10.lua
+++ b/lua/weapons/tacrp_m4star10.lua
@@ -88,6 +88,11 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 4,
+        RecoilResetTime = 0.3,
+        RecoilMaximum = 5
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AutoShotgun

--- a/lua/weapons/tacrp_m4star10.lua
+++ b/lua/weapons/tacrp_m4star10.lua
@@ -88,11 +88,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 4,
-        RecoilResetTime = 0.3,
-        RecoilMaximum = 5
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AutoShotgun

--- a/lua/weapons/tacrp_mg4.lua
+++ b/lua/weapons/tacrp_mg4.lua
@@ -72,6 +72,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.0015,
+        ReloadTimeMult = 1.15
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachineGun

--- a/lua/weapons/tacrp_mg4.lua
+++ b/lua/weapons/tacrp_mg4.lua
@@ -72,10 +72,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.0015,
-        ReloadTimeMult = 1.15
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachineGun

--- a/lua/weapons/tacrp_mg4.lua
+++ b/lua/weapons/tacrp_mg4.lua
@@ -73,8 +73,8 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.2,
-        ReloadTimeMult = 1.05
+        RecoilSpreadPenalty = 0.0015,
+        ReloadTimeMult = 1.15
     }
 }
 

--- a/lua/weapons/tacrp_mg4.lua
+++ b/lua/weapons/tacrp_mg4.lua
@@ -72,6 +72,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.2,
+        ReloadTimeMult = 1.05
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachineGun

--- a/lua/weapons/tacrp_mp5.lua
+++ b/lua/weapons/tacrp_mp5.lua
@@ -79,10 +79,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilPerShot = 1.25,
-        RecoilMaximum = 20
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_mp5.lua
+++ b/lua/weapons/tacrp_mp5.lua
@@ -79,6 +79,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilPerShot = 1.25,
+        RecoilMaximum = 20
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_mp7.lua
+++ b/lua/weapons/tacrp_mp7.lua
@@ -69,6 +69,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 20,
+        RecoilSpreadPenalty = 0.004
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_mp7.lua
+++ b/lua/weapons/tacrp_mp7.lua
@@ -69,10 +69,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 20,
-        RecoilSpreadPenalty = 0.004
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_mr96.lua
+++ b/lua/weapons/tacrp_mr96.lua
@@ -67,6 +67,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 2
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Magnum

--- a/lua/weapons/tacrp_mr96.lua
+++ b/lua/weapons/tacrp_mr96.lua
@@ -67,9 +67,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 2
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Magnum

--- a/lua/weapons/tacrp_mtx_dual.lua
+++ b/lua/weapons/tacrp_mtx_dual.lua
@@ -83,6 +83,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.003,
+        RecoilMax = 25
+    }
 }
 
 SWEP.TTTReplace = {["weapon_zm_pistol"] = 0.5, ["weapon_ttt_glock"] = 0.5}

--- a/lua/weapons/tacrp_mtx_dual.lua
+++ b/lua/weapons/tacrp_mtx_dual.lua
@@ -83,10 +83,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.003,
-        RecoilMax = 25
-    }
 }
 
 SWEP.TTTReplace = {["weapon_zm_pistol"] = 0.5, ["weapon_ttt_glock"] = 0.5}

--- a/lua/weapons/tacrp_p90.lua
+++ b/lua/weapons/tacrp_p90.lua
@@ -64,6 +64,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.002,
+        RecoilMaximum = 20
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_p90.lua
+++ b/lua/weapons/tacrp_p90.lua
@@ -64,10 +64,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.002,
-        RecoilMaximum = 20
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_pdw.lua
+++ b/lua/weapons/tacrp_pdw.lua
@@ -67,6 +67,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.003
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_pdw.lua
+++ b/lua/weapons/tacrp_pdw.lua
@@ -67,9 +67,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.003
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_sg551.lua
+++ b/lua/weapons/tacrp_sg551.lua
@@ -87,6 +87,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 20
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_sg551.lua
+++ b/lua/weapons/tacrp_sg551.lua
@@ -87,9 +87,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 20
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.AssaultRifle

--- a/lua/weapons/tacrp_skorpion.lua
+++ b/lua/weapons/tacrp_skorpion.lua
@@ -71,6 +71,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 10
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_skorpion.lua
+++ b/lua/weapons/tacrp_skorpion.lua
@@ -71,9 +71,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 10
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_spr.lua
+++ b/lua/weapons/tacrp_spr.lua
@@ -90,6 +90,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.03
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SniperRifle

--- a/lua/weapons/tacrp_spr.lua
+++ b/lua/weapons/tacrp_spr.lua
@@ -91,7 +91,7 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.03
+        HipFireSpreadPenalty = 0.015
     }
 }
 

--- a/lua/weapons/tacrp_spr.lua
+++ b/lua/weapons/tacrp_spr.lua
@@ -90,9 +90,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.015
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SniperRifle

--- a/lua/weapons/tacrp_spr.lua
+++ b/lua/weapons/tacrp_spr.lua
@@ -90,6 +90,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.015
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SniperRifle

--- a/lua/weapons/tacrp_superv.lua
+++ b/lua/weapons/tacrp_superv.lua
@@ -80,6 +80,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.002,
+        HipFireSpreadPenalty = 0.02
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_superv.lua
+++ b/lua/weapons/tacrp_superv.lua
@@ -80,10 +80,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.002,
-        HipFireSpreadPenalty = 0.02
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SMG

--- a/lua/weapons/tacrp_tgs12.lua
+++ b/lua/weapons/tacrp_tgs12.lua
@@ -89,10 +89,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilDissipationRate = 1.5,
-        HipFireSpreadPenalty = 0.04
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_tgs12.lua
+++ b/lua/weapons/tacrp_tgs12.lua
@@ -89,6 +89,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilDissipationRate = 1.5,
+        HipFireSpreadPenalty = 0.04
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Shotgun

--- a/lua/weapons/tacrp_uratio.lua
+++ b/lua/weapons/tacrp_uratio.lua
@@ -76,7 +76,7 @@ SWEP.BalanceStats = {
         ReloadSpeedMult = 1,
     },
     [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.04,
+        HipFireSpreadPenalty = 0.025,
         MoveSpreadPenalty = 0.02
     }
 }

--- a/lua/weapons/tacrp_uratio.lua
+++ b/lua/weapons/tacrp_uratio.lua
@@ -75,6 +75,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.025,
+        MoveSpreadPenalty = 0.02
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SniperRifle

--- a/lua/weapons/tacrp_uratio.lua
+++ b/lua/weapons/tacrp_uratio.lua
@@ -75,10 +75,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        HipFireSpreadPenalty = 0.025,
-        MoveSpreadPenalty = 0.02
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SniperRifle

--- a/lua/weapons/tacrp_uratio.lua
+++ b/lua/weapons/tacrp_uratio.lua
@@ -75,6 +75,10 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        HipFireSpreadPenalty = 0.04,
+        MoveSpreadPenalty = 0.02
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.SniperRifle

--- a/lua/weapons/tacrp_uzi.lua
+++ b/lua/weapons/tacrp_uzi.lua
@@ -65,6 +65,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.0024
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_uzi.lua
+++ b/lua/weapons/tacrp_uzi.lua
@@ -65,9 +65,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.0024
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_vertec.lua
+++ b/lua/weapons/tacrp_vertec.lua
@@ -94,9 +94,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilSpreadPenalty = 0.002
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Pistol

--- a/lua/weapons/tacrp_vertec.lua
+++ b/lua/weapons/tacrp_vertec.lua
@@ -94,6 +94,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.002
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.Pistol

--- a/lua/weapons/tacrp_vertec.lua
+++ b/lua/weapons/tacrp_vertec.lua
@@ -93,6 +93,9 @@ SWEP.BalanceStats = {
         SightedSpeedMult = 1,
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
+    },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilSpreadPenalty = 0.002
     }
 }
 

--- a/lua/weapons/tacrp_xd45.lua
+++ b/lua/weapons/tacrp_xd45.lua
@@ -83,6 +83,9 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
+    [TacRP.BALANCE_OLDSCHOOL] = {
+        RecoilMaximum = 20
+    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol

--- a/lua/weapons/tacrp_xd45.lua
+++ b/lua/weapons/tacrp_xd45.lua
@@ -83,9 +83,6 @@ SWEP.BalanceStats = {
         MeleeSpeedMult = 1,
         ReloadSpeedMult = 1,
     },
-    [TacRP.BALANCE_OLDSCHOOL] = {
-        RecoilMaximum = 20
-    }
 }
 
 SWEP.TTTReplace = TacRP.TTTReplacePreset.MachinePistol


### PR DESCRIPTION
A novelty balance mode that pursues something resembling old CS, with an emphasis on player movement and penalization of wild spraying.  This mode removes ironsights (weapons can still be aimed with optics mounted), significantly tightens hipfire and moving spread and amps up bloom intensity. 