### PR TITLE
Fix for Attachments didn't sync correctly

### DIFF
--- a/lua/tacrp/client/cl_net.lua
+++ b/lua/tacrp/client/cl_net.lua
@@ -1,5 +1,6 @@
 net.Receive("tacrp_networkweapon", function(len)
-    local wpn = net.ReadEntity()
+    local wpn_index = net.ReadUInt(13)
+    local wpn = Entity(wpn_index)
 
     -- When the server immediately calls NetworkWeapon on a new weapon,
     -- the client entity may not be valid or correct instantly.
@@ -17,6 +18,7 @@ net.Receive("tacrp_networkweapon", function(len)
         -- Wait until entity properly exists to pass on attachment info.
         -- Usually won't take more than 1 tick but ping may cause issues
         timer.Create(tname, 0, 100, function()
+            local wpn = Entity(wpn_index)
             if !IsValid(wpn) or !wpn.ArcticTacRP then return end
 
             wpn:ReceiveWeapon(ids)

--- a/lua/weapons/tacrp_base/sv_net.lua
+++ b/lua/weapons/tacrp_base/sv_net.lua
@@ -1,6 +1,6 @@
 function SWEP:NetworkWeapon(sendto)
     net.Start("TacRP_networkweapon")
-    net.WriteEntity(self)
+    net.WriteUInt(self:EntIndex(), 13)
 
     for slot, slottbl in pairs(self.Attachments) do
         if !slottbl.Installed then net.WriteUInt(0, TacRP.Attachments_Bits) continue end


### PR DESCRIPTION
## Fix for Attachments didn't sync correctly when `tacrp_free_atts` is 0

When `tacrp_free_atts` is `0`, the Attachment of the gun can not be synced correctly

this is because the function `SWEP:NetworkWeapon` never works

by following the sourcecode of [net.ReadEntity()](https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/includes/extensions/net.lua#L66-L73)

`local wpn = net.ReadEntity()`

the `wpn` will always be Invalid when `IsValid(wpn)` is false

# Changes

just transfer the entIndex instead of the original WriteEntity and use `local wpn = Entity(index)` to get the weapon everytime

this code is tested and its works for me