### PR TITLE
Avoid to draw pcf into DepthPass

### DIFF
--- a/lua/weapons/tacrp_base/cl_viewmodel.lua
+++ b/lua/weapons/tacrp_base/cl_viewmodel.lua
@@ -226,12 +226,15 @@ function SWEP:PreDrawViewModel()
     render.DepthRange(0.0, 0.1)
 end
 
-function SWEP:PostDrawViewModel()
+function SWEP:PostDrawViewModel(viewmodel, player, weapon, flags)
     cam.IgnoreZ(false)
 
     if self:GetValue("ScopeHideWeapon") and self:IsInScope() then
         render.SetBlend(1)
     end
+
+    local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+    if isDepthPass then return end
 
     cam.Start3D()
         cam.IgnoreZ(false)


### PR DESCRIPTION
Here was bug with Resolved Depth Buffer. NeedsDepthPass gmod func calls Resolved Depth Buffer writing, so this pull request fix pcf writing to depth.

Fixed bug:
<img width="1896" height="1053" alt="image" src="https://github.com/user-attachments/assets/e0a5980f-75d7-4c93-8492-7ebc48101c1e" />
