### PR TITLE
Replace `render.SetBlend` by `render.OverrideColorWriteEnable` on `cl_worldmodel.lua`

### DIFF
--- a/lua/weapons/tacrp_base/cl_viewmodel.lua
+++ b/lua/weapons/tacrp_base/cl_viewmodel.lua
@@ -207,7 +207,7 @@ end
 
 function SWEP:PreDrawViewModel()
     if self:GetValue("ScopeHideWeapon") and self:IsInScope() then
-        render.SetBlend(0)
+        render.OverrideColorWriteEnable(true, false)
     end
 
     // Set shell color on viewmodel for matproxy
@@ -235,7 +235,7 @@ function SWEP:PostDrawViewModel(viewmodel, player, weapon, flags)
     cam.IgnoreZ(false)
 
     if self:GetValue("ScopeHideWeapon") and self:IsInScope() then
-        render.SetBlend(1)
+        render.OverrideColorWriteEnable(false, false)
     end
 
     local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )


### PR DESCRIPTION
Seems `render.SetBlend` not makes effect on Resolved Depth Buffer. So `render.OverrideColorWriteEnable` does same result, but works also with Depth Buffer.

Pull request result:

https://github.com/user-attachments/assets/21a955f8-fbe4-4885-ab8a-30bb23cc84c8

Bug (fixed):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1d53f642-5e00-4a04-8821-c7579c3c82d2" />
