### PR TITLE
Remove `$alphatest` from `slide.vmt` of HK45

### DIFF
--- a/materials/models/tacint_extras/hk45c/slide.vmt
+++ b/materials/models/tacint_extras/hk45c/slide.vmt
@@ -5,7 +5,6 @@ VertexLitGeneric
 	"$halflambert"	"1"
 	"$nocull"	"1"
 	"$selfillum"	"1"
-	"$alphatest"	"1"
 
 	//"$envmap"	"env_cubemap"
 	"$normalmapalphaenvmapmask"     "1"


### PR DESCRIPTION
Depth write shader can't see `"$normalmapalphaenvmapmask"     "1"` param. Thats why it apply only `"$alphatest"	"1". And `$normalmapalphaenvmapmask` discard `$alphatest` on main scene. Thats why its looks fine on main scene. But buggy on Resolved Depth pass.

Bug:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/31c1074e-a9e0-4a1f-9b42-011ef9618108" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c448155c-2050-4f5f-8c82-8c8c54b6f7d9" />


Fixed:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ca9c929d-78e9-4b2c-bf33-0c2f0362421f" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b9fbe687-5295-4bcf-b0cb-c05cebbf0843" />

https://developer.valvesoftware.com/wiki/DepthWrite