### PR TITLE
Chanded `ENT.RenderGroup` of ents from `RENDERGROUP_TRANSLUCENT` to `RENDERGROUP_OPAQUE`

### DIFF
--- a/lua/entities/tacrp_ammo.lua
+++ b/lua/entities/tacrp_ammo.lua
@@ -166,8 +166,8 @@ elseif CLIENT then
         self:Draw()
     end
 
-    function ENT:Draw()
-        self:DrawModel()
+    function ENT:Draw(flags)
+        self:DrawModel(flags)
     end
 
 end

--- a/lua/entities/tacrp_ammo.lua
+++ b/lua/entities/tacrp_ammo.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "base_entity"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Ammo Pickup"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_c4.lua
+++ b/lua/entities/tacrp_ammo_c4.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "C4 Charge (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_charge.lua
+++ b/lua/entities/tacrp_ammo_charge.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Door Charge (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_crate.lua
+++ b/lua/entities/tacrp_ammo_crate.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Ammo Crate"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_crate_ttt.lua
+++ b/lua/entities/tacrp_ammo_crate_ttt.lua
@@ -240,8 +240,8 @@ elseif CLIENT then
         self:Draw()
     end
 
-    function ENT:Draw()
-        self:DrawModel()
+    function ENT:Draw(flags)
+        self:DrawModel(flags)
     end
 
 end

--- a/lua/entities/tacrp_ammo_fire.lua
+++ b/lua/entities/tacrp_ammo_fire.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Thermite Grenade (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_flashbang.lua
+++ b/lua/entities/tacrp_ammo_flashbang.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Flashbang (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_frag.lua
+++ b/lua/entities/tacrp_ammo_frag.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "base_entity"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Frag Grenade (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_gas.lua
+++ b/lua/entities/tacrp_ammo_gas.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "CS Gas Grenade (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_heal.lua
+++ b/lua/entities/tacrp_ammo_heal.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Medi-Smoke Canister (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_nuke.lua
+++ b/lua/entities/tacrp_ammo_nuke.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Nuclear Device (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_ammo_smoke.lua
+++ b/lua/entities/tacrp_ammo_smoke.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "tacrp_ammo_frag"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Smoke Grenade (Ammo)"
 ENT.Category                 = "Tactical RP"

--- a/lua/entities/tacrp_att.lua
+++ b/lua/entities/tacrp_att.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "base_entity"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Attachment"
 ENT.Category                 = "Tactical Intervention - Attachments"
@@ -112,8 +112,13 @@ elseif CLIENT then
         cam.End3D2D()
     end
 
-    function ENT:Draw()
-        self:DrawModel()
+    function ENT:Draw(flags)
+        local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+        
+        self:DrawModel(flags)
+
+        if isDepthPass then return end
+        
         local distsqr = (EyePos() - self:WorldSpaceCenter()):LengthSqr()
         if distsqr <= 262144 then -- 512^2
             local a = math.Clamp(1 - (distsqr - 196608) / 65536, 0, 1)

--- a/lua/entities/tacrp_bench.lua
+++ b/lua/entities/tacrp_bench.lua
@@ -63,6 +63,6 @@ function ENT:DrawTranslucent()
     end
 end
 
-function ENT:Draw()
-    self:DrawModel()
+function ENT:Draw(flags)
+    self:DrawModel(flags)
 end

--- a/lua/entities/tacrp_droppedmag.lua
+++ b/lua/entities/tacrp_droppedmag.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "base_entity"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Dropped Magazine"
 ENT.Category                 = ""

--- a/lua/entities/tacrp_droppedmag.lua
+++ b/lua/entities/tacrp_droppedmag.lua
@@ -138,6 +138,6 @@ function ENT:DrawTranslucent()
     self:Draw()
 end
 
-function ENT:Draw()
-    self:DrawModel()
+function ENT:Draw(flags)
+    self:DrawModel(flags)
 end

--- a/lua/entities/tacrp_proj_base.lua
+++ b/lua/entities/tacrp_proj_base.lua
@@ -2,7 +2,7 @@ AddCSLuaFile()
 
 ENT.Type                     = "anim"
 ENT.Base                     = "base_entity"
-ENT.RenderGroup              = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup              = RENDERGROUP_OPAQUE
 
 ENT.PrintName                = "Base Projectile"
 ENT.Category                 = ""

--- a/lua/entities/tacrp_proj_base.lua
+++ b/lua/entities/tacrp_proj_base.lua
@@ -583,10 +583,13 @@ end
 
 local mat = Material("effects/ar2_altfire1b")
 
-function ENT:Draw()
+function ENT:Draw(flags)
     if self:GetOwner() == LocalPlayer() and (self.SpawnTime + 0.05) > CurTime() then return end
 
-    self:DrawModel()
+    self:DrawModel(flags)
+
+    local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+    if isDepthPass then return end
 
     if self.FlareColor then
         local mult = self.SafetyFuse and math.Clamp((CurTime() - (self.SpawnTime + self.SafetyFuse)) / self.SafetyFuse, 0.1, 1) or 1

--- a/lua/entities/tacrp_proj_rpg7_improvised.lua
+++ b/lua/entities/tacrp_proj_rpg7_improvised.lua
@@ -243,8 +243,11 @@ end
 
 local mat = Material("effects/ar2_altfire1b")
 
-function ENT:Draw()
-    self:DrawModel()
+function ENT:Draw(flags)
+    self:DrawModel(flags)
+
+    local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+    if isDepthPass then return end
 
     if self.FlareColor and !self:GetNoBooster() then
         render.SetMaterial(mat)

--- a/lua/entities/tacrp_proj_rpg7_mortar.lua
+++ b/lua/entities/tacrp_proj_rpg7_mortar.lua
@@ -240,8 +240,11 @@ end
 
 local mat = Material("effects/ar2_altfire1b")
 
-function ENT:Draw()
-    self:DrawModel()
+function ENT:Draw(flags)
+    self:DrawModel(flags)
+
+    local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+    if isDepthPass then return end
 
     if self.FlareColor and !self:GetNoBooster() then
         render.SetMaterial(mat)


### PR DESCRIPTION
Bug:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2cf9182f-708c-46e8-a088-0a7bdc6c04b6" />

Fixed:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7200421c-b7a1-42fc-b01d-e62865064aea" />
